### PR TITLE
feat: Add manual control and refactor scheduling system

### DIFF
--- a/prisma/migrations/20250823053758_add_schedule_model/migration.sql
+++ b/prisma/migrations/20250823053758_add_schedule_model/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `fan_action ` on the `sensor_history` table. All the data in the column will be lost.
+  - You are about to drop the column `schedule_off_time` on the `settings` table. All the data in the column will be lost.
+  - You are about to drop the column `schedule_on_time` on the `settings` table. All the data in the column will be lost.
+  - You are about to drop the column `scheduled_days` on the `settings` table. All the data in the column will be lost.
+  - Added the required column `fan_action` to the `sensor_history` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."sensor_history" DROP COLUMN "fan_action ",
+ADD COLUMN     "fan_action" "public"."FanAction" NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."settings" DROP COLUMN "schedule_off_time",
+DROP COLUMN "schedule_on_time",
+DROP COLUMN "scheduled_days";
+
+-- CreateTable
+CREATE TABLE "public"."schedules" (
+    "id" UUID NOT NULL,
+    "setting_id" UUID NOT NULL,
+    "day" VARCHAR(3) NOT NULL,
+    "on_time" VARCHAR(5) NOT NULL,
+    "off_time" VARCHAR(5) NOT NULL,
+
+    CONSTRAINT "schedules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "schedules_setting_id_day_key" ON "public"."schedules"("setting_id", "day");
+
+-- AddForeignKey
+ALTER TABLE "public"."schedules" ADD CONSTRAINT "schedules_setting_id_fkey" FOREIGN KEY ("setting_id") REFERENCES "public"."settings"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,17 +49,28 @@ model Device {
 model Setting {
   id              String   @id @default(uuid()) @db.Uuid
   deviceId        String   @unique @map("device_id") @db.Uuid
-  scheduleEnabled Boolean  @default(false) @map("schedule_enabled")
   autoModeEnabled Boolean  @default(true) @map("auto_mode_enabled")
-  scheduleOnTime  String?  @map("schedule_on_time") @db.VarChar(5)
-  scheduleOffTime String?  @map("schedule_off_time") @db.VarChar(5)
-  scheduledDays   String[] @map("scheduled_days")
+  scheduleEnabled Boolean  @default(false) @map("schedule_enabled")
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @updatedAt @map("updated_at")
 
-  device Device @relation(fields: [deviceId], references: [id], onDelete: Cascade)
+  device    Device     @relation(fields: [deviceId], references: [id], onDelete: Cascade)
+  schedules Schedule[]
 
   @@map("settings")
+}
+
+model Schedule {
+  id        String @id @default(uuid()) @db.Uuid
+  settingId String @map("setting_id") @db.Uuid
+  day       String @db.VarChar(3)
+  onTime    String @map("on_time") @db.VarChar(5)
+  offTime   String @map("off_time") @db.VarChar(5)
+
+  setting Setting @relation(fields: [settingId], references: [id], onDelete: Cascade)
+
+  @@unique([settingId, day])
+  @@map("schedules")
 }
 
 model SensorHistory {

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,8 @@ Ikuti langkah-langkah berikut untuk menjalankan proyek ini di lingkungan lokal A
 1.  **Clone Repositori**
 
     ```bash
-    git clone [https://github.com/your-username/dmouv-smart-detection-backend.git](https://github.com/your-username/dmouv-smart-detection-backend.git)
-    cd dmouv-smart-detection-backend
+    git clone [https://github.com/your-username/backend-dmouv.git](https://github.com/your-username/backend-dmouv.git)
+    cd backend-dmouv
     ```
 
 2.  **Install Dependensi**
@@ -130,7 +130,7 @@ Anda bisa menjalankan aplikasi ini dengan dua cara:
 │ ├── routes/ # Definisi endpoint API
 │ ├── services/ # Logika bisnis inti
 │ └── utils/ # Utilitas (validasi)d
-├── .env # Variabel lingkungan (Jangan di-commit!)
+├── .env # Variabel lingkungan
 ├── app.js # Konfigurasi utama Express
 ├── docker-compose.yml # Konfigurasi Docker
 ├── Dockerfile # Definisi image Docker untuk aplikasi

--- a/src/controllers/device.controller.js
+++ b/src/controllers/device.controller.js
@@ -1,4 +1,5 @@
 import * as deviceService from "../services/device.service.js";
+import * as deviceControlService from "../services/device.control.service.js";
 
 export const onboardDevice = async (req, res, next) => {
   try {
@@ -21,6 +22,26 @@ export const onboardDevice = async (req, res, next) => {
         devices: result.devices,
       });
     }
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const controlDevice = async (req, res, next) => {
+  try {
+    const { deviceId } = req.params;
+    const { action } = req.body;
+
+    const updatedDevice = await deviceControlService.executeDeviceAction(
+      deviceId,
+      action,
+      "manual"
+    );
+
+    res.status(200).json({
+      message: `Device action '${action}' executed successfully.`,
+      device: updatedDevice,
+    });
   } catch (error) {
     next(error);
   }

--- a/src/controllers/settings.controller.js
+++ b/src/controllers/settings.controller.js
@@ -26,3 +26,40 @@ export const updateSettings = async (req, res, next) => {
     next(error);
   }
 };
+
+export const addOrUpdateSchedule = async (req, res, next) => {
+  try {
+    const { deviceId } = req.params;
+    const { day, onTime, offTime } = req.body;
+
+    const schedule = await settingsService.addOrUpdateScheduleByDevice(
+      deviceId,
+      {
+        day,
+        onTime,
+        offTime,
+      }
+    );
+
+    res.status(201).json({
+      message: `Schedule for ${day} has been successfully saved.`,
+      schedule,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteSchedule = async (req, res, next) => {
+  try {
+    const { deviceId, day } = req.params;
+
+    await settingsService.deleteScheduleByDay(deviceId, day);
+
+    res.status(200).json({
+      message: `Schedule for ${day} has been successfully deleted.`,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/devices.js
+++ b/src/routes/devices.js
@@ -3,7 +3,11 @@
 import express from "express";
 import { authenticateToken } from "../middleware/auth.js";
 import { validateRequest } from "../utils/validation.js";
-import { deviceOnboardingValidation } from "../utils/validation.js";
+import {
+  deviceOnboardingValidation,
+  deviceIdValidation,
+  deviceActionValidation,
+} from "../utils/validation.js";
 import * as deviceController from "../controllers/device.controller.js";
 
 const router = express.Router();
@@ -17,6 +21,18 @@ router.post(
   deviceOnboardingValidation,
   validateRequest,
   deviceController.onboardDevice
+);
+
+// @route   POST /api/device/:deviceId/action
+// @desc    Manually control a device (turn on/off).
+// @access  Private
+router.post(
+  "/:deviceId/action",
+  authenticateToken,
+  deviceIdValidation,
+  deviceActionValidation,
+  validateRequest,
+  deviceController.controlDevice
 );
 
 export default router;

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -4,32 +4,55 @@ import { validateRequest } from "../utils/validation.js";
 import {
   deviceIdValidation,
   updateSettingValidation,
+  scheduleValidation,
+  dayParamValidation,
 } from "../utils/validation.js";
 import * as settingsController from "../controllers/settings.controller.js";
 
 const router = express.Router();
+router.use(authenticateToken);
 
 // @route   GET /api/settings/:deviceId
-// @desc    Get settings for a specific device
+// @desc    Get settings and all schedules for a specific device
 // @access  Private
 router.get(
   "/:deviceId",
-  authenticateToken,
   deviceIdValidation,
   validateRequest,
   settingsController.getSettings
 );
 
 // @route   PATCH /api/settings/:deviceId
-// @desc    Update settings for a specific device
+// @desc    Update general settings (autoModeEnabled, scheduleEnabled)
 // @access  Private
 router.patch(
   "/:deviceId",
-  authenticateToken,
   deviceIdValidation,
   updateSettingValidation,
   validateRequest,
   settingsController.updateSettings
+);
+
+// @route   POST /api/settings/:deviceId/schedules
+// @desc    Add or update a schedule for a specific day
+// @access  Private
+router.post(
+  "/:deviceId/schedules",
+  deviceIdValidation,
+  scheduleValidation,
+  validateRequest,
+  settingsController.addOrUpdateSchedule
+);
+
+// @route   DELETE /api/settings/:deviceId/schedules/:day
+// @desc    Delete a schedule for a specific day (e.g., /Mon)
+// @access  Private
+router.delete(
+  "/:deviceId/schedules/:day",
+  deviceIdValidation,
+  dayParamValidation,
+  validateRequest,
+  settingsController.deleteSchedule
 );
 
 export default router;

--- a/src/services/settings.service.js
+++ b/src/services/settings.service.js
@@ -4,7 +4,14 @@ import { io } from "./socket.service.js";
 export const getSettingsByDeviceId = async (deviceId) => {
   const settings = await prisma.setting.findUnique({
     where: { deviceId },
-    include: { device: true },
+    include: {
+      device: true,
+      schedules: {
+        orderBy: {
+          day: "asc",
+        },
+      },
+    },
   });
 
   if (!settings) {
@@ -30,6 +37,74 @@ export const updateSettingsByDeviceId = async (deviceId, updateData) => {
   } catch (error) {
     if (error.code === "P2025") {
       const notFoundError = new Error("Settings not found for this device");
+      notFoundError.status = 404;
+      throw notFoundError;
+    }
+    throw error;
+  }
+};
+
+export const addOrUpdateScheduleByDevice = async (deviceId, scheduleData) => {
+  const { day, onTime, offTime } = scheduleData;
+
+  const setting = await prisma.setting.findUnique({
+    where: { deviceId },
+  });
+
+  if (!setting) {
+    const error = new Error("Settings not found for this device");
+    error.status = 404;
+    throw error;
+  }
+
+  const schedule = await prisma.schedule.upsert({
+    where: {
+      settingId_day: {
+        settingId: setting.id,
+        day: day,
+      },
+    },
+    update: {
+      onTime: onTime,
+      offTime: offTime,
+    },
+    create: {
+      settingId: setting.id,
+      day: day,
+      onTime: onTime,
+      offTime: offTime,
+    },
+  });
+
+  return schedule;
+};
+
+export const deleteScheduleByDay = async (deviceId, day) => {
+  const setting = await prisma.setting.findUnique({
+    where: { deviceId },
+  });
+
+  if (!setting) {
+    const error = new Error("Settings not found for this device");
+    error.status = 404;
+    throw error;
+  }
+
+  try {
+    const deletedSchedule = await prisma.schedule.delete({
+      where: {
+        settingId_day: {
+          settingId: setting.id,
+          day: day,
+        },
+      },
+    });
+    return deletedSchedule;
+  } catch (error) {
+    if (error.code === "P2025") {
+      const notFoundError = new Error(
+        `Schedule for day '${day}' not found for this device.`
+      );
       notFoundError.status = 404;
       throw notFoundError;
     }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -96,36 +96,18 @@ export const getHistoryValidation = [
     .isIn(["asc", "desc"])
     .withMessage("sortOrder must be 'asc' or 'desc'"),
 ];
-
 const timeFormatValidation = (value) => {
-  if (value === null || value === undefined) {
-    return true;
-  }
   if (!/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/.test(value)) {
     throw new Error("Invalid time format. Must be HH:mm (e.g., 08:00)");
   }
   return true;
 };
 
-const daysValidation = (value) => {
-  if (value === null || value === undefined) {
-    return true;
-  }
-  const validDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-  if (!Array.isArray(value)) {
-    throw new Error("scheduledDays must be an array");
-  }
-  const invalidDays = value.filter((day) => !validDays.includes(day));
-  if (invalidDays.length > 0) {
-    throw new Error(`Invalid days found: ${invalidDays.join(", ")}`);
-  }
-  return true;
-};
+const validDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 export const deviceIdValidation = [
   param("deviceId").isUUID().withMessage("Invalid deviceId format"),
 ];
-
 export const updateSettingValidation = [
   body("scheduleEnabled")
     .optional()
@@ -135,7 +117,32 @@ export const updateSettingValidation = [
     .optional()
     .isBoolean()
     .withMessage("autoModeEnabled must be a boolean"),
-  body("scheduleOnTime").optional().custom(timeFormatValidation),
-  body("scheduleOffTime").optional().custom(timeFormatValidation),
-  body("scheduledDays").optional().custom(daysValidation),
+];
+
+export const deviceActionValidation = [
+  body("action")
+    .notEmpty()
+    .withMessage("Action is required")
+    .isIn(["turn_on", "turn_off"])
+    .withMessage("Action must be either 'turn_on' or 'turn_off'"),
+];    
+
+export const scheduleValidation = [
+  body("day")
+    .isIn(validDays)
+    .withMessage(`Day must be one of: ${validDays.join(", ")}`),
+  body("onTime")
+    .notEmpty()
+    .withMessage("onTime is required")
+    .custom(timeFormatValidation),
+  body("offTime")
+    .notEmpty()
+    .withMessage("offTime is required")
+    .custom(timeFormatValidation),
+];
+
+export const dayParamValidation = [
+  param("day")
+    .isIn(validDays)
+    .withMessage(`Day parameter must be one of: ${validDays.join(", ")}`),
 ];


### PR DESCRIPTION
# Perubahan Utama:
## Kontrol Manual:
- Menambahkan endpoint POST /api/device/:deviceId/action untuk memungkinkan pengguna menyalakan/mematikan perangkat secara manual.

## Refactor Sistem Penjadwalan:
- Mengganti model jadwal yang lama dengan tabel Schedule baru yang terpisah.
- Pengguna dapat mengatur jam nyala/mati yang berbeda untuk setiap hari dalam seminggu.
- Menambahkan endpoint POST dan DELETE untuk mengelola jadwal harian (/api/settings/:deviceId/schedules).